### PR TITLE
yet another hotfix of gh actions

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,7 +12,7 @@
   "rules": {
     "no-console": "off",
     "operator-linebreak": "off",
-    "linebreak-style": ["error", "windows"],
+    "linebreak-style": "off",
     "comma-dangle": "off"
   }
 }

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,7 +1,6 @@
 {
   "arrowParens": "always",
   "bracketSpacing": true,
-  "endOfLine": "crlf",
   "printWidth": 80,
   "quoteProps": "as-needed",
   "requirePragma": false,


### PR DESCRIPTION
I've been testing why the "check style" action fails, and this is what I've found about it.

In the _eslint_ check at #15, we can see that it fails with the following message

> Expected linebreaks to be 'CRLF' but found 'LF'  linebreak-style

But at 175de1c I changed the _prettier_'s configuration to use 'CRLF'. So, Why this error appears in the actions but doesn't appear locally?

Let me first talk about `autocrlf`. This git's configuration can change the EoL of a file according to the OS ('CRLF' for _Windows_ and 'LF' for _Linux_/_macOS_). We can see it better with the graph made by the user _Antony Hatchkins_ in this _StackOverflow_ question (https://stackoverflow.com/a/20653073).
```
core.autocrlf=true:      core.autocrlf=input:     core.autocrlf=false:
                                             
        repo                     repo                     repo
      ^      V                 ^      V                 ^      V
     /        \               /        \               /        \
crlf->lf    lf->crlf     crlf->lf       \             /          \      
   /            \           /            \           /            \
```

In other words, locally I could have my files ending with 'CRLF' but when they are sent to the repository their EoL will change to 'LF'. So, when the GitHub action is run it will find 'LF' instead of 'CRLF'.

The solution I propose with this (hopefully last) fix is to **delete the _prettier_'s rule 'endOfLine'** and **set off the _eslint_'s rule called 'linebreak-style'**. This should let the user decides its own EoL, _prettier_ won't overwrite them. Also, _eslint_ shouldn't check what EoL every file have.

I already tested this at my own fork and you can see the results here (https://github.com/gonza7aav/miciudad-api/pull/1). Also if you want to test there something, you are welcome!

I wrote this explanation because it's a weird error where the _prettier_'s format doesn't actually reach the repository. And may help someone with a similar bug. 

Being December 31st, I want to apologize for all the changes and fixes which didn't work; and also **Happy New Year to everyone!**

